### PR TITLE
geant4: New version 10.2 and improved deps

### DIFF
--- a/packages/geant4/package.py
+++ b/packages/geant4/package.py
@@ -9,14 +9,16 @@ class Geant4(Package):
     version('10.02.p01', 'b81f7082a15f6a34b720b6f15c6289cfe4ddbbbdcef0dc52719f71fac95f7f1c')
     version('10.01.p03', '4fb4175cc0dabcd517443fbdccd97439')
 
+    variant('qt', default=False, description='Enable Qt support')
+
     depends_on("cmake")
 
     depends_on("clhep@2.3.1.1+cxx11", when="@10.02.p01")
     depends_on("clhep@2.2.0.4+cxx11", when="@10.01.p03")
-
     depends_on("expat")
     depends_on("zlib")
     depends_on("xerces-c")
+    depends_on("qt@4.8:", when="+qt")
 
     def install(self, spec, prefix):
         cmake_args = list(std_cmake_args)

--- a/packages/geant4/package.py
+++ b/packages/geant4/package.py
@@ -6,18 +6,27 @@ class Geant4(Package):
     homepage = "http://geant4.cern.ch/"
     url      = "http://geant4.cern.ch/support/source/geant4.10.01.p03.tar.gz"
 
+    version('10.02.p01', 'b81f7082a15f6a34b720b6f15c6289cfe4ddbbbdcef0dc52719f71fac95f7f1c')
     version('10.01.p03', '4fb4175cc0dabcd517443fbdccd97439')
 
-    depends_on("xerces-c")
     depends_on("cmake")
 
-    def install(self, spec, prefix):
+    depends_on("clhep@2.3.1.1+cxx11", when="@10.02.p01")
+    depends_on("clhep@2.2.0.4+cxx11", when="@10.01.p03")
 
+    depends_on("expat")
+    depends_on("zlib")
+    depends_on("xerces-c")
+
+    def install(self, spec, prefix):
         cmake_args = list(std_cmake_args)
         cmake_args.append('-DXERCESC_ROOT_DIR:STRING=%s'%spec['xerces-c'].prefix)
         cmake_args.append('-DGEANT4_BUILD_CXXSTD=c++11')
 
-        cmake_args += ['-DGEANT4_USE_GDML=ON', '-DGEANT4_USE_RAYTRACER_X11=ON']
+        cmake_args += ['-DGEANT4_USE_GDML=ON',
+                       '-DGEANT4_USE_SYSTEM_EXPAT=ON',
+                       '-DGEANT4_USE_SYSTEM_ZLIB=ON',
+                       '-DGEANT4_USE_SYSTEM_CLHEP=ON']
 
         # fixme: turn off data for now and maybe each data set should
         # go into a separate package to cut down on disk usage between
@@ -27,13 +36,9 @@ class Geant4(Package):
         # http://geant4.web.cern.ch/geant4/UserDocumentation/UsersGuides/InstallationGuide/html/ch02s03.html
         # fixme: likely things that need addressing:
         # -DGEANT4_USE_OPENGL_X11=ON
-        # -DGEANT4_USE_SYSTEM_CLHEP
-        # -DGEANT4_USE_SYSTEM_EXPAT
 
         if '+qt' in spec:
             cmake_args.append('-DGEANT4_USE_QT=ON')
-
-
 
         build_directory = join_path(self.stage.path, 'spack-build')
         source_directory = self.stage.source_path


### PR DESCRIPTION
Add new version 10.2.p01 with sha256 hash

Add expat and zlib as external dependencies, adding needed flags
to Geant4 cmake flags.

Use external CLHEP, making depends_on use explicit versions per
version of Geant4 following upstream release/testing notes. Include
explicit cxx11 variant as CLHEP may not be built with cxx11, but
Geant4 always is. Note this needs review.

Remove use of GEANT4_USE_RAYTRACER_X11 flag as X11 is not yet
provideded through spack, and there is no(?) current way to place
a requirement on system packages (needed rpms/debs, or Xquartz
on OS X).