### PR TITLE
[WIP] Gaudi v27r1 in spack

### DIFF
--- a/packages/aida/package.py
+++ b/packages/aida/package.py
@@ -1,0 +1,15 @@
+from spack import *
+import os
+import glob
+
+class Aida(Package):
+    """AIDA Headers."""
+    homepage = "http://www.example.com"
+    url      = "http://service-spi.web.cern.ch/service-spi/external/tarFiles/aida-3.2.1-src.tar.gz"
+
+    version('3.2.1', 'c35073da04abfdd96ac9f4801f3da473')
+
+    def install(self, spec, prefix):
+        mkdirp(prefix.include)
+        cp = which('cp')
+        cp('-r', 'src/cpp/AIDA', prefix + '/include')

--- a/packages/cppunit/package.py
+++ b/packages/cppunit/package.py
@@ -29,6 +29,8 @@ class Cppunit(Package):
 
     def install(self, spec, prefix):
         # FIXME: Modify the configure line to suit your build system here.
+        import os
+        os.environ["LDFLAGS"] = os.environ.get("LDFLAG", "") + " -ldl "
         configure('--prefix=%s' % prefix)
 
         # FIXME: Add logic to build and install here

--- a/packages/gaudi/package.py
+++ b/packages/gaudi/package.py
@@ -7,9 +7,13 @@ class Gaudi(Package):
 
     version('v27r1', '7d7283ca2c3d8d050af3db2b89a25ab629abbb57')
 
+    depends_on("python")
     depends_on("root")
-    depends_on("boost")
+    depends_on("py-qmtest")
+    depends_on("clhep")
+    depends_on("boost@1.59.0")
     depends_on("cppunit")
+    depends_on("aida")
 
     def install(self, spec, prefix):
         options = []
@@ -21,7 +25,7 @@ class Gaudi(Package):
         if '+debug' in spec:
             options.append('-DCMAKE_BUILD_TYPE:STRING=Debug ')
 
-	options.append("-DCMAKE_TOOLCHAIN_FILE=" + source_directory +"/toolchain.cmake")
+	#options.append("-DCMAKE_TOOLCHAIN_FILE=" + source_directory +"/toolchain.cmake")
 
         with working_dir(build_directory, create=True):
             import os

--- a/packages/gaudi/package.py
+++ b/packages/gaudi/package.py
@@ -1,0 +1,35 @@
+from spack import *
+
+class Gaudi(Package):
+    """Gaudi framework."""
+    homepage = "https://gaudi.cern.ch"
+    url      = "http://gaudi.cern.ch"
+
+    version('v27r1', '7d7283ca2c3d8d050af3db2b89a25ab629abbb57')
+
+    depends_on("root")
+    depends_on("boost")
+    depends_on("cppunit")
+
+    def install(self, spec, prefix):
+        options = []
+        options.extend(std_cmake_args)
+
+        build_directory = join_path(self.stage.path, 'spack-build')
+        source_directory = self.stage.source_path
+
+        if '+debug' in spec:
+            options.append('-DCMAKE_BUILD_TYPE:STRING=Debug ')
+
+	options.append("-DCMAKE_TOOLCHAIN_FILE=" + source_directory +"/toolchain.cmake")
+
+        with working_dir(build_directory, create=True):
+            import os
+            cmake(source_directory , *options)
+            make()
+            make("install")
+
+    def url_for_version(self, version):
+        """Handle ROOT's unusual version string."""
+        #return "http://lhcbproject.web.cern.ch/lhcbproject/dist/GAUDI/GAUDI_GAUDI_%s.tar.gz" % version
+        return "http://cern.ch/bcouturi/Gaudi_%s.tar.gz" % version

--- a/packages/gaudi/package.py
+++ b/packages/gaudi/package.py
@@ -11,9 +11,10 @@ class Gaudi(Package):
     depends_on("root")
     depends_on("py-qmtest")
     depends_on("clhep")
-    depends_on("boost@1.59.0")
+    depends_on("boost@1.59.0+python")
     depends_on("cppunit")
     depends_on("aida")
+    depends_on("tbb@20140122oss")
 
     def install(self, spec, prefix):
         options = []
@@ -30,7 +31,7 @@ class Gaudi(Package):
         with working_dir(build_directory, create=True):
             import os
             cmake(source_directory , *options)
-            make()
+            make(" VERBOSE=1")
             make("install")
 
     def url_for_version(self, version):

--- a/packages/py-qmtest/package.py
+++ b/packages/py-qmtest/package.py
@@ -1,0 +1,26 @@
+# To install:
+#
+#     spack install py-qmtest
+#
+# You can always get back here to change things with:
+#
+#     spack edit py-qmtest
+#
+# See the spack documentation for more information on building
+# packages.
+#
+from spack import *
+
+class PyQmtest(Package):
+    """ QmTest tes package for python."""
+    homepage = "http://legacy.python.org/workshops/2002-02/papers/01/index.htm"
+    url      = "http://service-spi.web.cern.ch/service-spi/external/tarFiles/qmtest-2.4.1.tar.gz"
+
+    version('2.4.1', '860d4795351453013c9aaab246fd93ba')
+    version('2.4'  , 'b1c7cd4aa78a0fda1a6598ece98f6033')
+
+    depends_on("python")
+
+    def install(self, spec, prefix):
+        python('setup.py', 'install', '--prefix=%s' % prefix)
+

--- a/packages/root/package.py
+++ b/packages/root/package.py
@@ -15,7 +15,7 @@ class Root(Package):
     depends_on("pcre")
     depends_on("fftw")
 
-    depends_on("graphviz")
+    #depends_on("graphviz")
     depends_on("python")
     depends_on("gsl")
     depends_on("libxml2+python")

--- a/packages/tbb/package.py
+++ b/packages/tbb/package.py
@@ -1,0 +1,94 @@
+# FIXME:
+# This is a template package file for Spack.  We've conveniently
+# put "FIXME" labels next to all the things you'll want to change.
+#
+# Once you've edited all the FIXME's, delete this whole message,
+# save this file, and test out your package like this:
+#
+#     spack install tbb
+#
+# You can always get back here to change things with:
+#
+#     spack edit tbb
+#
+# See the spack documentation for more information on building
+# packages.
+#
+from spack import *
+import glob
+
+class Tbb(Package):
+    """Repacked TBB with correct version """
+    homepage = "http://tbb.intel.com"
+    url      = "http://service-spi.web.cern.ch/service-spi/external/tarFiles/tbb42_20140122oss_src.tgz"
+
+    version('20140122oss', '70345f907f5ffe9b2bc3b7ed0d6508bc')
+
+    def coerce_to_spack(self,tbb_build_subdir):
+        for compiler in ["icc","gcc","clang"]:
+              fs = glob.glob(join_path(tbb_build_subdir,"*.%s.inc" % compiler ))
+              for f in fs:
+                  lines = open(f).readlines()
+                  of = open(f,"w")
+                  for l in lines:
+                      if l.strip().startswith("CPLUS ="):
+                        of.write("# coerced to spack\n")
+                        of.write("CPLUS = $(CXX)\n")
+                      elif l.strip().startswith("CPLUS ="):
+                        of.write("# coerced to spack\n")
+                        of.write("CONLY = $(CC)\n")
+                      else:
+                        of.write(l);
+
+
+
+    def install(self, spec, prefix):
+        #
+        # we need to follow TBB's compiler selection logic to get the proper build + link flags
+        # but we still need to use spack's compiler wrappers
+        # to accomplish this, we do two things:
+        #
+        # * Look at the spack spec to determine which compiler we should pass to tbb's Makefile
+        #
+        # * patch tbb's build system to use the compiler wrappers (CC, CXX) for
+        #    icc, gcc, clang
+        #    (see coerce_to_spack())
+        #
+        self.coerce_to_spack("build")
+
+        if spec.satisfies('%clang'):
+            tbb_compiler = "clang"
+        elif spec.satisfies('%intel'):
+            tbb_compiler = "icc"
+        else:
+            tbb_compiler = "gcc"
+
+
+        mkdirp(prefix)
+        mkdirp(prefix.lib)
+
+        #
+        # tbb does not have a configure script or make install target
+        # we simply call make, and try to put the pieces together
+        #
+        make("compiler=%s"  %(tbb_compiler))
+
+        # install headers to {prefix}/include
+        install_tree('include',prefix.include)
+
+        # install libs to {prefix}/lib
+        tbb_lib_names = ["libtbb",
+                         "libtbbmalloc",
+                         "libtbbmalloc_proxy"]
+
+        for lib_name in tbb_lib_names:
+            # install release libs
+            fs = glob.glob(join_path("build","*release",lib_name + ".*"))
+            for f in fs:
+                install(f, prefix.lib)
+            # install debug libs if they exist
+            fs = glob.glob(join_path("build","*debug",lib_name + "_debug.*"))
+            for f in fs:
+                install(f, prefix.lib)
+
+


### PR DESCRIPTION

As a preparation for the Workshop Hackathon, I had a go at compiling Gaudi v27r1 using spack and the dependencies already know to spack/hep-spack, adding the missing ones from LCG on the way.

This is a quick hack, to start discussion, not a clean implementation.

I managed to compile on a Ubuntu 16.04 (forcing gcc 4.9 instead of the default compiler) and can run the binary tests. The python path isn't set properly.

P.S. Graphviz excluded from ROOT as I had problems compiling it, but not for reasons linked to Gaudi itself.