### PR TITLE
Adding generic packages used in FCCSW

### DIFF
--- a/packages/dd4hep/package.py
+++ b/packages/dd4hep/package.py
@@ -1,0 +1,43 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+
+from spack import *
+
+
+class Dd4hep(CMakePackage):
+    """software framework of the FCC project"""
+    homepage = "https://github.com/AIDASoft/DD4hep/"
+    url      = "https://github.com/AIDASoft/DD4hep/archive/v00-19.tar.gz"
+
+    depends_on('cmake', type='build')
+    depends_on('boost')
+    depends_on('xerces-c')
+    depends_on('geant4')
+
+    def configure_args(self):
+        spec = self.spec
+        return [
+            '-DCMAKE_BUILD_TYPE:STRING=%s' ('Debug' if '+debug' in spec else 'Release')
+        ]

--- a/packages/dd4hep/package.py
+++ b/packages/dd4hep/package.py
@@ -48,3 +48,7 @@ class Dd4hep(CMakePackage):
         return [
             '-DCMAKE_BUILD_TYPE:STRING=%s' ('Debug' if '+debug' in spec else 'Release')
         ]
+
+
+    def setup_dependent_environment(self, spack_env, run_env, dspec):
+        spack_env.set('DD4hep_DIR', self.prefix)

--- a/packages/dd4hep/package.py
+++ b/packages/dd4hep/package.py
@@ -31,6 +31,13 @@ class Dd4hep(CMakePackage):
     homepage = "https://github.com/AIDASoft/DD4hep/"
     url      = "https://github.com/AIDASoft/DD4hep/archive/v00-19.tar.gz"
 
+    version('19', 'f5e162261433082c6363e6c96c08c66e')
+    version('18', 'ab4f3033c9ac7494f863bc88eedbdcf5')
+    version('17', '9b9ea29790aa887893484ed8a4afae68')
+    version('16', '4df618f2f7b10f0e995d7f30214f0850')
+    version('15', 'cf0b50903e37c30f2361318c79f115ce')
+
+
     depends_on('cmake', type='build')
     depends_on('boost')
     depends_on('xerces-c')

--- a/packages/delphes/package.py
+++ b/packages/delphes/package.py
@@ -1,0 +1,57 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+
+from spack import *
+
+
+class Delphes(CMakePackage):
+    """Event data model description library"""
+
+    # FIXME: Add a proper url for your package's homepage here.
+    homepage = "https://github.com/delphes/delphes"
+    url      = "https://github.com/delphes/delphes/archive/3.3.3.tar.gz"
+
+    version('16', '542ce3c064094f2b04456395227621cf')
+    version('15', 'f04f7c7495deb84193b49058ea50c111')
+    version('14', '1dd287ab24d6c237ccb428cc6dd4a4bf')
+    version('13', 'faca7e76269c88099d95ef74525b732f')
+    version('12', '450f801f7d60c09bf77cd6013d364c65')
+    version('11', '8bcb45a0a38c17d0cf762dadd49d5a02')
+    version('10', 'dfc76e38838c15bad29ebc9ebb3d0724')
+    version('09', 'ac3ad6211009feaaa58d734101cbc99e')
+    version('3.3.3', '1a2099854a4131cd53bd0b90ca0dff3d')
+    version('develop', git='https://github.com/delphes/delphes.git', branch='master')
+
+    depends_on('cmake', type='build')
+    depends_on('root')
+
+    def configure_args(self):
+        spec = self.spec
+        return [
+            '-DCMAKE_BUILD_TYPE:STRING=%s' ('Debug' if '+debug' in spec else 'Release')
+        ]
+
+    def setup_dependent_environment(self, spack_env, run_env, dspec):
+        spack_env.set('DELPHES_DIR', self.prefix)

--- a/packages/delphes/package.py
+++ b/packages/delphes/package.py
@@ -33,16 +33,9 @@ class Delphes(CMakePackage):
     homepage = "https://github.com/delphes/delphes"
     url      = "https://github.com/delphes/delphes/archive/3.3.3.tar.gz"
 
-    version('16', '542ce3c064094f2b04456395227621cf')
-    version('15', 'f04f7c7495deb84193b49058ea50c111')
-    version('14', '1dd287ab24d6c237ccb428cc6dd4a4bf')
-    version('13', 'faca7e76269c88099d95ef74525b732f')
-    version('12', '450f801f7d60c09bf77cd6013d364c65')
-    version('11', '8bcb45a0a38c17d0cf762dadd49d5a02')
-    version('10', 'dfc76e38838c15bad29ebc9ebb3d0724')
-    version('09', 'ac3ad6211009feaaa58d734101cbc99e')
     version('3.3.3', '1a2099854a4131cd53bd0b90ca0dff3d')
     version('3.4.0', 'cfe26bfc2638d195c9880238c6f7adc4')
+    version('3.4.1pre01', git=homepage, tag='3.4.1pre01')
     version('develop', git='https://github.com/delphes/delphes.git', branch='master')
 
     depends_on('cmake', type='build')

--- a/packages/delphes/package.py
+++ b/packages/delphes/package.py
@@ -42,6 +42,7 @@ class Delphes(CMakePackage):
     version('10', 'dfc76e38838c15bad29ebc9ebb3d0724')
     version('09', 'ac3ad6211009feaaa58d734101cbc99e')
     version('3.3.3', '1a2099854a4131cd53bd0b90ca0dff3d')
+    version('3.4.0', 'cfe26bfc2638d195c9880238c6f7adc4')
     version('develop', git='https://github.com/delphes/delphes.git', branch='master')
 
     depends_on('cmake', type='build')

--- a/packages/gaudi/package.py
+++ b/packages/gaudi/package.py
@@ -3,20 +3,21 @@ from spack import *
 class Gaudi(Package):
     """Gaudi framework."""
     homepage = "https://gaudi.cern.ch"
-    url      = "http://gaudi.cern.ch"
+    url      = "https://gaudi.cern.ch"
 
     version('v27r1', git='https://gitlab.cern.ch/gaudi/Gaudi.git', tag='v27r1')
+    version('v28r0', git='https://gitlab.cern.ch/gaudi/Gaudi.git', tag='v28r0')
 
     depends_on("python")
     depends_on("root")
     depends_on("py-qmtest")
     depends_on("clhep")
-    depends_on("boost@1.59.0+python")
+    depends_on("boost")
     depends_on("cppunit")
     depends_on("aida")
-    depends_on("tbb@20140122oss")
+    depends_on("tbb")
     depends_on("gperftools")
-    depends_on("heppdt@2.06.01")
+    depends_on("heppdt")
 
     def install(self, spec, prefix):
         options = []

--- a/packages/gaudi/package.py
+++ b/packages/gaudi/package.py
@@ -7,6 +7,7 @@ class Gaudi(Package):
 
     version('v27r1', git='https://gitlab.cern.ch/gaudi/Gaudi.git', tag='v27r1')
     version('v28r0', git='https://gitlab.cern.ch/gaudi/Gaudi.git', tag='v28r0')
+    version('v28r1', git='https://gitlab.cern.ch/gaudi/Gaudi.git', tag='v28r1')
 
     depends_on("python")
     depends_on("root")

--- a/packages/hepmc/package.py
+++ b/packages/hepmc/package.py
@@ -53,3 +53,6 @@ class Hepmc(Package):
             cmake(*options)
             make()
             make('install')
+
+    def setup_dependent_environment(self, spack_env, run_env, dspec):
+        spack_env.set('HEPMC_PREFIX', self.prefix)

--- a/packages/podio/package.py
+++ b/packages/podio/package.py
@@ -1,0 +1,54 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+
+from spack import *
+
+
+class Podio(CMakePackage):
+    """Event data model description library"""
+
+    # FIXME: Add a proper url for your package's homepage here.
+    homepage = "http://www.example.com"
+    url      = "https://github.com/HEP-FCC/podio/archive/v0.4.tar.gz"
+
+    version('0.4.1', '6c3e166bfca6a7d36de05cbde3a55713')
+    version('0.4'  , '9cb8b0dd4510ed1ee05e03982196151d')
+    version('0.3.2', 'ed07d059e0fe79336a8c9c8e8be6d4e1')
+    version('0.3.1', 'a7bc95a99af6fc50ae39539e5aa1087e')
+    version('0.3'  , '04411e2a48126846f576ca292e4656a0')
+    version('develop', git='https://github.com/HEP-FCC/podio.git', branch='master')
+
+    depends_on('cmake', type='build')
+    depends_on('py-pyyaml', type='run')
+    depends_on('root')
+
+    def configure_args(self):
+        spec = self.spec
+        return [
+            '-DCMAKE_BUILD_TYPE:STRING=%s' ('Debug' if '+debug' in spec else 'Release')
+        ]
+
+    def setup_dependent_environment(self, spack_env, run_env, dspec):
+        spack_env.set('PODIO', self.prefix)

--- a/packages/pythia/package.py
+++ b/packages/pythia/package.py
@@ -1,0 +1,49 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+
+from spack import *
+import os
+
+class Pythia(Package):
+    """Event generator pythia"""
+
+    homepage = "http://home.thep.lu.se/~torbjorn/Pythia.html"
+    url      = "http://home.thep.lu.se/~torbjorn/pythia8/pythia8219.tgz"
+
+    version('8219', '3459b52b5da1deae52cbddefa6196feb')
+    version('8215', 'b4653133e6ab1782a5a4aa66eda6a54b')
+    version('8212', '0886d1b2827d8f0cd2ae69b925045f40')
+    version('8210', '685d61f08ca486caa6d5dfa35089e4ab')
+    version('8209', '1b9e9dc2f8a2c2db63bce739242fbc12')
+
+    def install(self, spec, prefix):
+        configure("--prefix=%s" % prefix)
+        make()
+        make("install")
+
+    def setup_dependent_environment(self, spack_env, run_env, dspec):
+        spack_env.set('PYTHIA8_DIR', self.prefix)
+        spack_env.set('PYTHIA8_XML', os.path.join(self.prefix, "share", "Pythia8", "xmldoc"))
+        spack_env.set('PYTHIA8DATA', os.path.join(self.prefix, "share", "Pythia8", "xmldoc"))

--- a/packages/root/package.py
+++ b/packages/root/package.py
@@ -32,6 +32,7 @@ class Root(Package):
     homepage = "https://root.cern.ch"
     url      = "https://root.cern.ch/download/root_v6.07.02.source.tar.gz"
 
+    version('6.08.02', '50c4dbb8aa81124aa58524e776fd4b4b')
     version('6.06.08', '6ef0fe9bd9f88f3ce8890e3651142ee4')
     version('6.06.06', '4308449892210c8d36e36924261fea26')
     version('6.06.04', '55a2f98dd4cea79c9c4e32407c2d6d17')


### PR DESCRIPTION
- Packages added in this PR:
  - Fast simulation toolkit [Delphes](https://github.com/delphes/delphes)
  - Library to generate data models: [PODIO](https://github.com/HEP-FCC/podio)
  - Generator [Pythia8](http://home.thep.lu.se/~torbjorn/Pythia.html)
  - Detector description toolkit [DD4hep](https://github.com/AIDASoft/DD4hep)
- Adding new versions to ROOT & Gaudi
- Removing hard-coded dependency versions from the Gaudi package description 